### PR TITLE
fix: correct repo name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Vespa CLI
-      uses: vespa-engine/setup-vespa-cli@v1
+      uses: vespa-engine/setup-vespa-cli-action@v1
 
     - name: Do something with the vespa CLI
       run: |


### PR DESCRIPTION
## What

Corrects example in README from `vespa-engine/setup-vespa-cli` to `vespa-engine/setup-vespa-cli-action`

## Why

Copy-Paste is not your friend if the data source is wrong...

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
